### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 10, 15]
+        java: [8, 11]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         run: ./gradlew assemble

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,11 @@ jobs:
       matrix:
         java: [8, 10, 15]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         run: ./gradlew assemble
@@ -29,5 +30,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
This includes a switch to the Eclipse Temurin JDK. With the Azul Zulu distribution, we were getting JDK crashes during CI runs.